### PR TITLE
Accept a directory: argument

### DIFF
--- a/Tests/SHLLMTests/Phi3Tests.swift
+++ b/Tests/SHLLMTests/Phi3Tests.swift
@@ -1,6 +1,12 @@
 @testable import SHLLM
 import Testing
 
+extension Phi3 {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
 @Test
 func canLoadAndQueryModel() async throws {
     let phi3 = try await Phi3()

--- a/bin/download.sh
+++ b/bin/download.sh
@@ -38,17 +38,20 @@ if [[ -z "${id}" ]]; then
   exit 2
 fi
 
+project=$(dirname "$0")
+pushd "$project/.." &>/dev/null
+
 metaurl="https://huggingface.co/api/models/mlx-community/${id}"
 echo "${metaurl}"
 
 files=$(curl -s "${metaurl}" | jq -r '.siblings[].rfilename')
 echo "${files}"
 
-pushd Sources/SHLLM/Resources
+pushd Sources/SHLLM/Resources &>/dev/null
 
 mkdir -p "${id}"
 
-pushd "${id}"
+pushd "${id}" &>/dev/null
 
 for file in ${files[@]}; do
   curl -L -# -o "${file}" "https://huggingface.co/mlx-community/${id}/resolve/main/${file}"


### PR DESCRIPTION
We intend to download the models in our app, possibly in the background, so this package should just take a directory and only use the bundle for the tests IMO.

Please feel free to modify this however you want, I just wanted to convey my idea to not rely on the bundle directory in “production.” 