### PR TITLE
Expose all models

### DIFF
--- a/Sources/SHLLM/ActorLock.swift
+++ b/Sources/SHLLM/ActorLock.swift
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Lock intended for use within an actor in order to prevent reentrancy in actor methods which
+/// themselves contain suspension points.
+public actor ActorLock {
+    private var busy = false
+    private var queue: ArraySlice<CheckedContinuation<Void, Never>> = []
+
+    public init() {}
+
+    public func withLock<
+        T: Sendable,
+        E
+    >(_ body: @Sendable () async throws(E) -> T) async throws(E) -> T {
+        while busy {
+            await withCheckedContinuation { cc in
+                queue.append(cc)
+            }
+        }
+        busy = true
+        defer {
+            busy = false
+            if let next = queue.popFirst() {
+                next.resume(returning: ())
+            } else {
+                queue = [] // reallocate buffer if it's empty
+            }
+        }
+        return try await body()
+    }
+}
+
+/// Small concurrency-compatible wrapper to provide only locked, non-reentrant access to its
+/// value.
+public final class AsyncLockedValue<Wrapped: Sendable> {
+    @usableFromInline let lock = ActorLock()
+    /// Don't use this from outside this class. Is internal to be inlinable.
+    @usableFromInline var value: Wrapped
+    public init(_ value: Wrapped) {
+        self.value = value
+    }
+
+    @discardableResult @inlinable
+    public func withLock<
+        Result: Sendable,
+        E
+    >(_ block: @Sendable (inout Wrapped) async throws(E) -> Result) async throws(E)
+        -> Result
+    {
+        try await lock.withLock { () throws(E) -> Result in try await block(&value) }
+    }
+}
+
+extension AsyncLockedValue: @unchecked Sendable where Wrapped: Sendable {}

--- a/Sources/SHLLM/LLM.swift
+++ b/Sources/SHLLM/LLM.swift
@@ -45,6 +45,13 @@ final class LLM {
         )
     }
 
+    static func mistralNemo(directory: URL) async throws -> LLM {
+        try await Self(
+            directory: directory,
+            modelInit: LlamaModel.init
+        )
+    }
+
     static func openELM(directory: URL) async throws -> LLM {
         try await Self(
             directory: directory,
@@ -77,6 +84,13 @@ final class LLM {
         try await Self(
             directory: directory,
             modelInit: Qwen2Model.init
+        )
+    }
+
+    static func smolLM(directory: URL) async throws -> LLM {
+        try await Self(
+            directory: directory,
+            modelInit: LlamaModel.init
         )
     }
 

--- a/Sources/SHLLM/LLM.swift
+++ b/Sources/SHLLM/LLM.swift
@@ -5,7 +5,7 @@ import MLXLLM
 import MLXLMCommon
 import Tokenizers
 
-final class LLM {
+public final class LLM {
     private let directory: URL
     private let context: ModelContext
     private let configuration: ModelConfiguration
@@ -39,13 +39,6 @@ final class LLM {
     }
 
     static func llama(directory: URL) async throws -> LLM {
-        try await Self(
-            directory: directory,
-            modelInit: LlamaModel.init
-        )
-    }
-
-    static func mistralNemo(directory: URL) async throws -> LLM {
         try await Self(
             directory: directory,
             modelInit: LlamaModel.init

--- a/Sources/SHLLM/LLM.swift
+++ b/Sources/SHLLM/LLM.swift
@@ -1,0 +1,191 @@
+import Foundation
+import struct Hub.Config
+import MLX
+import MLXLLM
+import MLXLMCommon
+import Tokenizers
+
+final class LLM {
+    private let directory: URL
+    private let context: ModelContext
+    private let configuration: ModelConfiguration
+
+    static func cohere(directory: URL) async throws -> LLM {
+        try await Self(
+            directory: directory,
+            modelInit: CohereModel.init
+        )
+    }
+
+    static func gemma(directory: URL) async throws -> LLM {
+        try await Self(
+            directory: directory,
+            modelInit: GemmaModel.init
+        )
+    }
+
+    static func gemma2(directory: URL) async throws -> LLM {
+        try await Self(
+            directory: directory,
+            modelInit: Gemma2Model.init
+        )
+    }
+
+    static func internLM2(directory: URL) async throws -> LLM {
+        try await Self(
+            directory: directory,
+            modelInit: InternLM2Model.init
+        )
+    }
+
+    static func llama(directory: URL) async throws -> LLM {
+        try await Self(
+            directory: directory,
+            modelInit: LlamaModel.init
+        )
+    }
+
+    static func openELM(directory: URL) async throws -> LLM {
+        try await Self(
+            directory: directory,
+            modelInit: OpenELMModel.init
+        )
+    }
+
+    static func phi(directory: URL) async throws -> LLM {
+        try await Self(
+            directory: directory,
+            modelInit: PhiModel.init
+        )
+    }
+
+    static func phi3(directory: URL) async throws -> LLM {
+        try await Self(
+            directory: directory,
+            modelInit: Phi3Model.init
+        )
+    }
+
+    static func phiMoE(directory: URL) async throws -> LLM {
+        try await Self(
+            directory: directory,
+            modelInit: PhiMoEModel.init
+        )
+    }
+
+    static func qwen2(directory: URL) async throws -> LLM {
+        try await Self(
+            directory: directory,
+            modelInit: Qwen2Model.init
+        )
+    }
+
+    static func starcoder2(directory: URL) async throws -> LLM {
+        try await Self(
+            directory: directory,
+            modelInit: Starcoder2Model.init
+        )
+    }
+
+    private init<Configuration: Decodable>(
+        directory: URL,
+        modelInit: (Configuration) -> some LanguageModel
+    ) async throws {
+        self.directory = directory
+        let decoder = JSONDecoder()
+
+        let config = try Data(
+            contentsOf: directory.appending(
+                path: "config.json",
+                directoryHint: .notDirectory
+            )
+        )
+
+        let baseConfig = try decoder.decode(
+            BaseConfiguration.self,
+            from: config
+        )
+
+        let modelConfig = try decoder.decode(
+            Configuration.self,
+            from: config
+        )
+        let model = modelInit(modelConfig)
+
+        try loadWeights(
+            modelDirectory: directory,
+            model: model,
+            quantization: baseConfig.quantization
+        )
+
+        guard let tokenizerConfigJSON = try JSONSerialization.jsonObject(
+            with: try Data(contentsOf: directory.appending(
+                path: "tokenizer_config.json",
+                directoryHint: .notDirectory
+            ))
+        ) as? [NSString: Any] else {
+            throw SHLLMError.invalidOrMissingConfig(
+                "tokenizer_config.json"
+            )
+        }
+
+        let tokenizerConfig = Config(tokenizerConfigJSON)
+
+        guard let tokenizerDataJSON = try JSONSerialization.jsonObject(
+            with: try Data(contentsOf: directory.appending(
+                path: "tokenizer.json",
+                directoryHint: .notDirectory
+            ))
+        ) as? [NSString: Any] else {
+            throw SHLLMError.invalidOrMissingConfig(
+                "tokenizer.json"
+            )
+        }
+
+        let tokenizerData = Config(tokenizerDataJSON)
+
+        let tokenizer = try PreTrainedTokenizer(
+            tokenizerConfig: tokenizerConfig,
+            tokenizerData: tokenizerData
+        )
+
+        configuration = ModelConfiguration(
+            directory: directory,
+            overrideTokenizer: nil,
+            defaultPrompt: "You are a helpful assistant."
+        )
+
+        context = ModelContext(
+            configuration: configuration,
+            model: model,
+            processor: LLMUserInputProcessor(
+                tokenizer: tokenizer,
+                configuration: configuration
+            ),
+            tokenizer: tokenizer
+        )
+    }
+}
+
+extension LLM {
+    func request(
+        _ input: UserInput,
+        maxTokenCount: Int = 1024 * 1024
+    ) async throws -> String {
+        let input = try await context.processor.prepare(input: input)
+
+        let result = try MLXLMCommon.generate(
+            input: input,
+            parameters: .init(),
+            context: context
+        ) { tokens in
+            if tokens.count >= maxTokenCount {
+                .stop
+            } else {
+                .more
+            }
+        }
+
+        return result.output
+    }
+}

--- a/Sources/SHLLM/ModelProtocol.swift
+++ b/Sources/SHLLM/ModelProtocol.swift
@@ -1,0 +1,17 @@
+import Foundation
+import MLXLMCommon
+
+public protocol ModelProtocol {
+    var llm: AsyncLockedValue<LLM> { get async }
+}
+
+public extension ModelProtocol {
+    func request(
+        _ input: UserInput,
+        maxTokenCount: Int = 1024 * 1024
+    ) async throws -> String {
+        try await llm.withLock { llm in
+            try await llm.request(input, maxTokenCount: maxTokenCount)
+        }
+    }
+}

--- a/Sources/SHLLM/Models/CodeLlama.swift
+++ b/Sources/SHLLM/Models/CodeLlama.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public actor Mistral7B: ModelProtocol {
+public actor CodeLlama: ModelProtocol {
     public let llm: AsyncLockedValue<LLM>
 
     public init(directory: URL) async throws {
@@ -9,10 +9,10 @@ public actor Mistral7B: ModelProtocol {
     }
 }
 
-extension Mistral7B {
+extension CodeLlama {
     static var bundleDirectory: URL {
         get throws {
-            let dir = "Mistral-7B-Instruct-v0.3-4bit"
+            let dir = "CodeLlama-13b-Instruct-hf-4bit-MLX"
             guard let url = Bundle.shllm.url(
                 forResource: dir,
                 withExtension: nil,

--- a/Sources/SHLLM/Models/DeepSeekR1.swift
+++ b/Sources/SHLLM/Models/DeepSeekR1.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public actor DeepSeekR1: ModelProtocol {
+    public let llm: AsyncLockedValue<LLM>
+
+    public init(directory: URL) async throws {
+        let llm = try await LLM.qwen2(directory: directory)
+        self.llm = .init(llm)
+    }
+}
+
+extension DeepSeekR1 {
+    static var bundleDirectory: URL {
+        get throws {
+            let dir = "DeepSeek-R1-Distill-Qwen-7B-4bit"
+            guard let url = Bundle.shllm.url(
+                forResource: dir,
+                withExtension: nil,
+                subdirectory: "Resources"
+            ) else {
+                throw SHLLMError.directoryNotFound(dir)
+            }
+            return url
+        }
+    }
+}

--- a/Sources/SHLLM/Models/Gemma.swift
+++ b/Sources/SHLLM/Models/Gemma.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public actor Gemma: ModelProtocol {
+    public let llm: AsyncLockedValue<LLM>
+
+    public init(directory: URL) async throws {
+        let llm = try await LLM.gemma(directory: directory)
+        self.llm = .init(llm)
+    }
+}
+
+extension Gemma {
+    static var bundleDirectory: URL {
+        get throws {
+            let dir = "quantized-gemma-2b-it"
+            guard let url = Bundle.shllm.url(
+                forResource: dir,
+                withExtension: nil,
+                subdirectory: "Resources"
+            ) else {
+                throw SHLLMError.directoryNotFound(dir)
+            }
+            return url
+        }
+    }
+}

--- a/Sources/SHLLM/Models/Gemma2-2B.swift
+++ b/Sources/SHLLM/Models/Gemma2-2B.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public actor Gemma2_2B: ModelProtocol {
+    public let llm: AsyncLockedValue<LLM>
+
+    public init(directory: URL) async throws {
+        let llm = try await LLM.gemma2(directory: directory)
+        self.llm = .init(llm)
+    }
+}
+
+extension Gemma2_2B {
+    static var bundleDirectory: URL {
+        get throws {
+            let dir = "gemma-2-2b-it-4bit"
+            guard let url = Bundle.shllm.url(
+                forResource: dir,
+                withExtension: nil,
+                subdirectory: "Resources"
+            ) else {
+                throw SHLLMError.directoryNotFound(dir)
+            }
+            return url
+        }
+    }
+}

--- a/Sources/SHLLM/Models/Gemma2-9B.swift
+++ b/Sources/SHLLM/Models/Gemma2-9B.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public actor Gemma2_9B: ModelProtocol {
+    public let llm: AsyncLockedValue<LLM>
+
+    public init(directory: URL) async throws {
+        let llm = try await LLM.gemma2(directory: directory)
+        self.llm = .init(llm)
+    }
+}
+
+extension Gemma2_9B {
+    static var bundleDirectory: URL {
+        get throws {
+            let dir = "gemma-2-9b-it-4bit"
+            guard let url = Bundle.shllm.url(
+                forResource: dir,
+                withExtension: nil,
+                subdirectory: "Resources"
+            ) else {
+                throw SHLLMError.directoryNotFound(dir)
+            }
+            return url
+        }
+    }
+}

--- a/Sources/SHLLM/Models/Llama3-8B.swift
+++ b/Sources/SHLLM/Models/Llama3-8B.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public actor Llama3_8B: ModelProtocol {
+    public let llm: AsyncLockedValue<LLM>
+
+    public init(directory: URL) async throws {
+        let llm = try await LLM.llama(directory: directory)
+        self.llm = .init(llm)
+    }
+}
+
+extension Llama3_8B {
+    static var bundleDirectory: URL {
+        get throws {
+            let dir = "Meta-Llama-3-8B-Instruct-4bit"
+            guard let url = Bundle.shllm.url(
+                forResource: dir,
+                withExtension: nil,
+                subdirectory: "Resources"
+            ) else {
+                throw SHLLMError.directoryNotFound(dir)
+            }
+            return url
+        }
+    }
+}

--- a/Sources/SHLLM/Models/Llama3_1-8B.swift
+++ b/Sources/SHLLM/Models/Llama3_1-8B.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public actor Llama3_1__8B: ModelProtocol {
+    public let llm: AsyncLockedValue<LLM>
+
+    public init(directory: URL) async throws {
+        let llm = try await LLM.llama(directory: directory)
+        self.llm = .init(llm)
+    }
+}
+
+extension Llama3_1__8B {
+    static var bundleDirectory: URL {
+        get throws {
+            let dir = "Meta-Llama-3.1-8B-Instruct-4bit"
+            guard let url = Bundle.shllm.url(
+                forResource: dir,
+                withExtension: nil,
+                subdirectory: "Resources"
+            ) else {
+                throw SHLLMError.directoryNotFound(dir)
+            }
+            return url
+        }
+    }
+}

--- a/Sources/SHLLM/Models/Llama3_2-1B.swift
+++ b/Sources/SHLLM/Models/Llama3_2-1B.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public actor Llama3_2__1B: ModelProtocol {
+    public let llm: AsyncLockedValue<LLM>
+
+    public init(directory: URL) async throws {
+        let llm = try await LLM.llama(directory: directory)
+        self.llm = .init(llm)
+    }
+}
+
+extension Llama3_2__1B {
+    static var bundleDirectory: URL {
+        get throws {
+            let dir = "Llama-3.2-1B-Instruct-4bit"
+            guard let url = Bundle.shllm.url(
+                forResource: dir,
+                withExtension: nil,
+                subdirectory: "Resources"
+            ) else {
+                throw SHLLMError.directoryNotFound(dir)
+            }
+            return url
+        }
+    }
+}

--- a/Sources/SHLLM/Models/Llama3_2-3B.swift
+++ b/Sources/SHLLM/Models/Llama3_2-3B.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public actor Llama3_2__3B: ModelProtocol {
+    public let llm: AsyncLockedValue<LLM>
+
+    public init(directory: URL) async throws {
+        let llm = try await LLM.llama(directory: directory)
+        self.llm = .init(llm)
+    }
+}
+
+extension Llama3_2__3B {
+    static var bundleDirectory: URL {
+        get throws {
+            let dir = "Llama-3.2-3B-Instruct-4bit"
+            guard let url = Bundle.shllm.url(
+                forResource: dir,
+                withExtension: nil,
+                subdirectory: "Resources"
+            ) else {
+                throw SHLLMError.directoryNotFound(dir)
+            }
+            return url
+        }
+    }
+}

--- a/Sources/SHLLM/Models/Mistral7B.swift
+++ b/Sources/SHLLM/Models/Mistral7B.swift
@@ -5,7 +5,7 @@ import MLXLLM
 import MLXLMCommon
 import Tokenizers
 
-public actor SmolLM: ModelProtocol {
+public actor Mistral7B: ModelProtocol {
     public let llm: AsyncLockedValue<LLM>
 
     public init(directory: URL) async throws {
@@ -14,10 +14,10 @@ public actor SmolLM: ModelProtocol {
     }
 }
 
-extension SmolLM {
+extension Mistral7B {
     static var bundleDirectory: URL {
         get throws {
-            let dir = "SmolLM-135M-Instruct-4bit"
+            let dir = "Mistral-7B-Instruct-v0.3-4bit"
             guard let url = Bundle.shllm.url(
                 forResource: dir,
                 withExtension: nil,

--- a/Sources/SHLLM/Models/MistralNemo.swift
+++ b/Sources/SHLLM/Models/MistralNemo.swift
@@ -5,11 +5,11 @@ import MLXLLM
 import MLXLMCommon
 import Tokenizers
 
-public actor Phi3 {
+public actor MistralNemo {
     private let llm: AsyncLockedValue<LLM>
 
     public init(directory: URL) async throws {
-        let llm = try await LLM.phi3(directory: directory)
+        let llm = try await LLM.mistralNemo(directory: directory)
         self.llm = .init(llm)
     }
 
@@ -23,16 +23,16 @@ public actor Phi3 {
     }
 }
 
-extension Phi3 {
+extension MistralNemo {
     static var bundleDirectory: URL {
         get throws {
+            let dir = "Mistral-Nemo-Instruct-2407-4bit"
             guard let url = Bundle.shllm.url(
-                forResource: "Phi-3.5-mini-instruct-4bit",
+                forResource: dir,
                 withExtension: nil,
                 subdirectory: "Resources"
             ) else {
-                throw SHLLMError
-                    .directoryNotFound("Phi-3.5-mini-instruct-4bit")
+                throw SHLLMError.directoryNotFound(dir)
             }
             return url
         }

--- a/Sources/SHLLM/Models/MistralNemo.swift
+++ b/Sources/SHLLM/Models/MistralNemo.swift
@@ -1,9 +1,4 @@
 import Foundation
-import struct Hub.Config
-import MLX
-import MLXLLM
-import MLXLMCommon
-import Tokenizers
 
 public actor MistralNemo: ModelProtocol {
     public let llm: AsyncLockedValue<LLM>

--- a/Sources/SHLLM/Models/MistralNemo.swift
+++ b/Sources/SHLLM/Models/MistralNemo.swift
@@ -5,21 +5,12 @@ import MLXLLM
 import MLXLMCommon
 import Tokenizers
 
-public actor MistralNemo {
-    private let llm: AsyncLockedValue<LLM>
+public actor MistralNemo: ModelProtocol {
+    public let llm: AsyncLockedValue<LLM>
 
     public init(directory: URL) async throws {
-        let llm = try await LLM.mistralNemo(directory: directory)
+        let llm = try await LLM.llama(directory: directory)
         self.llm = .init(llm)
-    }
-
-    public func request(
-        _ input: UserInput,
-        maxTokenCount: Int = 1024 * 1024
-    ) async throws -> String {
-        try await llm.withLock { llm in
-            try await llm.request(input, maxTokenCount: maxTokenCount)
-        }
     }
 }
 

--- a/Sources/SHLLM/Models/OpenELM.swift
+++ b/Sources/SHLLM/Models/OpenELM.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public actor OpenELM: ModelProtocol {
+    public let llm: AsyncLockedValue<LLM>
+
+    public init(directory: URL) async throws {
+        let llm = try await LLM.openELM(directory: directory)
+        self.llm = .init(llm)
+    }
+}
+
+extension OpenELM {
+    static var bundleDirectory: URL {
+        get throws {
+            let dir = "OpenELM-270M-Instruct"
+            guard let url = Bundle.shllm.url(
+                forResource: dir,
+                withExtension: nil,
+                subdirectory: "Resources"
+            ) else {
+                throw SHLLMError.directoryNotFound(dir)
+            }
+            return url
+        }
+    }
+}

--- a/Sources/SHLLM/Models/Phi2.swift
+++ b/Sources/SHLLM/Models/Phi2.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public actor Phi2: ModelProtocol {
+    public let llm: AsyncLockedValue<LLM>
+
+    public init(directory: URL) async throws {
+        let llm = try await LLM.phi(directory: directory)
+        self.llm = .init(llm)
+    }
+}
+
+extension Phi2 {
+    static var bundleDirectory: URL {
+        get throws {
+            let dir = "phi-2-hf-4bit-mlx"
+            guard let url = Bundle.shllm.url(
+                forResource: dir,
+                withExtension: nil,
+                subdirectory: "Resources"
+            ) else {
+                throw SHLLMError.directoryNotFound(dir)
+            }
+            return url
+        }
+    }
+}

--- a/Sources/SHLLM/Models/Phi3.swift
+++ b/Sources/SHLLM/Models/Phi3.swift
@@ -5,21 +5,12 @@ import MLXLLM
 import MLXLMCommon
 import Tokenizers
 
-public actor Phi3 {
-    private let llm: AsyncLockedValue<LLM>
+public actor Phi3: ModelProtocol {
+    public let llm: AsyncLockedValue<LLM>
 
     public init(directory: URL) async throws {
         let llm = try await LLM.phi3(directory: directory)
         self.llm = .init(llm)
-    }
-
-    public func request(
-        _ input: UserInput,
-        maxTokenCount: Int = 1024 * 1024
-    ) async throws -> String {
-        try await llm.withLock { llm in
-            try await llm.request(input, maxTokenCount: maxTokenCount)
-        }
     }
 }
 

--- a/Sources/SHLLM/Models/Phi3.swift
+++ b/Sources/SHLLM/Models/Phi3.swift
@@ -1,0 +1,40 @@
+import Foundation
+import struct Hub.Config
+import MLX
+import MLXLLM
+import MLXLMCommon
+import Tokenizers
+
+public actor Phi3 {
+    private let llm: AsyncLockedValue<LLM>
+
+    public init(directory: URL) async throws {
+        let llm = try await LLM.phi3(directory: directory)
+        self.llm = .init(llm)
+    }
+
+    public func request(
+        _ input: UserInput,
+        maxTokenCount: Int = 1024 * 1024
+    ) async throws -> String {
+        try await llm.withLock { llm in
+            try await llm.request(input, maxTokenCount: maxTokenCount)
+        }
+    }
+}
+
+extension Phi3 {
+    static var bundleDirectory: URL {
+        get throws {
+            let dir = "Phi-3.5-mini-instruct-4bit"
+            guard let url = Bundle.shllm.url(
+                forResource: dir,
+                withExtension: nil,
+                subdirectory: "Resources"
+            ) else {
+                throw SHLLMError.directoryNotFound(dir)
+            }
+            return url
+        }
+    }
+}

--- a/Sources/SHLLM/Models/Phi3.swift
+++ b/Sources/SHLLM/Models/Phi3.swift
@@ -1,9 +1,4 @@
 import Foundation
-import struct Hub.Config
-import MLX
-import MLXLLM
-import MLXLMCommon
-import Tokenizers
 
 public actor Phi3: ModelProtocol {
     public let llm: AsyncLockedValue<LLM>

--- a/Sources/SHLLM/Models/PhiMoE.swift
+++ b/Sources/SHLLM/Models/PhiMoE.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public actor PhiMoE: ModelProtocol {
+    public let llm: AsyncLockedValue<LLM>
+
+    public init(directory: URL) async throws {
+        let llm = try await LLM.phiMoE(directory: directory)
+        self.llm = .init(llm)
+    }
+}
+
+extension PhiMoE {
+    static var bundleDirectory: URL {
+        get throws {
+            let dir = "Phi-3.5-MoE-instruct-4bit"
+            guard let url = Bundle.shllm.url(
+                forResource: dir,
+                withExtension: nil,
+                subdirectory: "Resources"
+            ) else {
+                throw SHLLMError.directoryNotFound(dir)
+            }
+            return url
+        }
+    }
+}

--- a/Sources/SHLLM/Models/Qwen1_5.swift
+++ b/Sources/SHLLM/Models/Qwen1_5.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public actor Qwen1_5: ModelProtocol {
+    public let llm: AsyncLockedValue<LLM>
+
+    public init(directory: URL) async throws {
+        let llm = try await LLM.qwen2(directory: directory)
+        self.llm = .init(llm)
+    }
+}
+
+extension Qwen1_5 {
+    static var bundleDirectory: URL {
+        get throws {
+            let dir = "Qwen1.5-0.5B-Chat-4bit"
+            guard let url = Bundle.shllm.url(
+                forResource: dir,
+                withExtension: nil,
+                subdirectory: "Resources"
+            ) else {
+                throw SHLLMError.directoryNotFound(dir)
+            }
+            return url
+        }
+    }
+}

--- a/Sources/SHLLM/Models/Qwen2_5-1_5B.swift
+++ b/Sources/SHLLM/Models/Qwen2_5-1_5B.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public actor Qwen2_5__1_5B: ModelProtocol {
+    public let llm: AsyncLockedValue<LLM>
+
+    public init(directory: URL) async throws {
+        let llm = try await LLM.qwen2(directory: directory)
+        self.llm = .init(llm)
+    }
+}
+
+extension Qwen2_5__1_5B {
+    static var bundleDirectory: URL {
+        get throws {
+            let dir = "Qwen2.5-1.5B-Instruct-4bit"
+            guard let url = Bundle.shllm.url(
+                forResource: dir,
+                withExtension: nil,
+                subdirectory: "Resources"
+            ) else {
+                throw SHLLMError.directoryNotFound(dir)
+            }
+            return url
+        }
+    }
+}

--- a/Sources/SHLLM/Models/Qwen2_5-7B.swift
+++ b/Sources/SHLLM/Models/Qwen2_5-7B.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public actor Qwen2_5__7B: ModelProtocol {
+    public let llm: AsyncLockedValue<LLM>
+
+    public init(directory: URL) async throws {
+        let llm = try await LLM.qwen2(directory: directory)
+        self.llm = .init(llm)
+    }
+}
+
+extension Qwen2_5__7B {
+    static var bundleDirectory: URL {
+        get throws {
+            let dir = "Qwen2.5-7B-Instruct-4bit"
+            guard let url = Bundle.shllm.url(
+                forResource: dir,
+                withExtension: nil,
+                subdirectory: "Resources"
+            ) else {
+                throw SHLLMError.directoryNotFound(dir)
+            }
+            return url
+        }
+    }
+}

--- a/Sources/SHLLM/Models/SmolLM.swift
+++ b/Sources/SHLLM/Models/SmolLM.swift
@@ -1,9 +1,4 @@
 import Foundation
-import struct Hub.Config
-import MLX
-import MLXLLM
-import MLXLMCommon
-import Tokenizers
 
 public actor SmolLM: ModelProtocol {
     public let llm: AsyncLockedValue<LLM>

--- a/Sources/SHLLM/Models/SmolLM.swift
+++ b/Sources/SHLLM/Models/SmolLM.swift
@@ -1,0 +1,40 @@
+import Foundation
+import struct Hub.Config
+import MLX
+import MLXLLM
+import MLXLMCommon
+import Tokenizers
+
+public actor SmolLM {
+    private let llm: AsyncLockedValue<LLM>
+
+    public init(directory: URL) async throws {
+        let llm = try await LLM.llama(directory: directory)
+        self.llm = .init(llm)
+    }
+
+    public func request(
+        _ input: UserInput,
+        maxTokenCount: Int = 1024 * 1024
+    ) async throws -> String {
+        try await llm.withLock { llm in
+            try await llm.request(input, maxTokenCount: maxTokenCount)
+        }
+    }
+}
+
+extension SmolLM {
+    static var bundleDirectory: URL {
+        get throws {
+            let dir = "SmolLM-135M-Instruct-4bit"
+            guard let url = Bundle.shllm.url(
+                forResource: dir,
+                withExtension: nil,
+                subdirectory: "Resources"
+            ) else {
+                throw SHLLMError.directoryNotFound(dir)
+            }
+            return url
+        }
+    }
+}

--- a/Sources/SHLLM/Phi3.swift
+++ b/Sources/SHLLM/Phi3.swift
@@ -6,103 +6,20 @@ import MLXLMCommon
 import Tokenizers
 
 public actor Phi3 {
-    private let context: ModelContext
-    private let configuration: ModelConfiguration
-    private let directory: URL
+    private let llm: AsyncLockedValue<LLM>
 
-    public init(directory dir: URL) async throws {
-        directory = dir
-        let decoder = JSONDecoder()
-
-        let config = try Data(
-                contentsOf: directory.appending(
-                    path: "config.json",
-                    directoryHint: .notDirectory
-                )
-            )
-
-        let baseConfig = try decoder.decode(
-            BaseConfiguration.self,
-            from: config
-        )
-
-        let phi3Config = try decoder.decode(
-            Phi3Configuration.self,
-            from: config
-        )
-        let model = Phi3Model(phi3Config)
-
-        try loadWeights(
-            modelDirectory: directory,
-            model: model,
-            quantization: baseConfig.quantization
-        )
-
-        guard let tokenizerConfigJSON = try JSONSerialization.jsonObject(
-            with: try Data(contentsOf: directory.appending(
-                path: "tokenizer_config.json",
-                directoryHint: .notDirectory
-            ))) as? [NSString: Any] else {
-            throw SHLLMError.invalidOrMissingConfig(
-                "tokenizer_config.json"
-            )
-        }
-
-        let tokenizerConfig = Config(tokenizerConfigJSON)
-
-        guard let tokenizerDataJSON = try JSONSerialization.jsonObject(
-            with: try Data(contentsOf: directory.appending(
-                path: "tokenizer.json",
-                directoryHint: .notDirectory
-            ))) as? [NSString: Any] else {
-            throw SHLLMError.invalidOrMissingConfig(
-                "tokenizer.json"
-            )
-        }
-
-        let tokenizerData = Config(tokenizerDataJSON)
-
-        let tokenizer = try PreTrainedTokenizer(
-            tokenizerConfig: tokenizerConfig,
-            tokenizerData: tokenizerData
-        )
-
-        configuration = ModelConfiguration(
-            directory: directory,
-            overrideTokenizer: nil,
-            defaultPrompt: "You are a helpful assistant."
-        )
-
-        context = ModelContext(
-            configuration: configuration,
-            model: model,
-            processor: LLMUserInputProcessor(
-                tokenizer: tokenizer,
-                configuration: configuration
-            ),
-            tokenizer: tokenizer
-        )
+    public init(directory: URL) async throws {
+        let llm = try await LLM.phi3(directory: directory)
+        self.llm = .init(llm)
     }
 
     public func request(
         _ input: UserInput,
         maxTokenCount: Int = 1024 * 1024
     ) async throws -> String {
-        let input = try await context.processor.prepare(input: input)
-
-        let result = try MLXLMCommon.generate(
-            input: input,
-            parameters: .init(),
-            context: context
-        ) { tokens in
-            if tokens.count >= maxTokenCount {
-                .stop
-            } else {
-                .more
-            }
+        try await llm.withLock { llm in
+            try await llm.request(input, maxTokenCount: maxTokenCount)
         }
-
-        return result.output
     }
 }
 

--- a/Tests/SHLLMTests/Models/CodeLlamaTests.swift
+++ b/Tests/SHLLMTests/Models/CodeLlamaTests.swift
@@ -1,0 +1,19 @@
+@testable import SHLLM
+import Testing
+
+private extension CodeLlama {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
+@Test
+func canLoadAndQueryCodeLlama() async throws {
+    let llm = try await CodeLlama()
+    let result = try await llm.request(.init(messages: [
+        ["role": "system", "content": "You are a helpful assistant."],
+        ["role": "user", "content": "Express the meaning of life in a JavaScript function."],
+    ]))
+    Swift.print(result)
+    #expect(!result.isEmpty)
+}

--- a/Tests/SHLLMTests/Models/DeepSeekR1Tests.swift
+++ b/Tests/SHLLMTests/Models/DeepSeekR1Tests.swift
@@ -1,0 +1,19 @@
+@testable import SHLLM
+import Testing
+
+private extension DeepSeekR1 {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
+@Test
+func canLoadAndQueryDeepSeekR1() async throws {
+    let llm = try await DeepSeekR1()
+    let result = try await llm.request(.init(messages: [
+        ["role": "system", "content": "You are a helpful assistant."],
+        ["role": "user", "content": "What is the meaning of life?"],
+    ]))
+    Swift.print(result)
+    #expect(!result.isEmpty)
+}

--- a/Tests/SHLLMTests/Models/Gemma2-2BTests.swift
+++ b/Tests/SHLLMTests/Models/Gemma2-2BTests.swift
@@ -1,0 +1,19 @@
+@testable import SHLLM
+import Testing
+
+private extension Gemma2_2B {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
+@Test
+func canLoadAndQueryGemma2_2B() async throws {
+    let llm = try await Gemma2_2B()
+    let result = try await llm.request(.init(messages: [
+        ["role": "system", "content": "You are a helpful assistant."],
+        ["role": "user", "content": "What is the meaning of life?"],
+    ]))
+    Swift.print(result)
+    #expect(!result.isEmpty)
+}

--- a/Tests/SHLLMTests/Models/Gemma2-9BTests.swift
+++ b/Tests/SHLLMTests/Models/Gemma2-9BTests.swift
@@ -1,0 +1,19 @@
+@testable import SHLLM
+import Testing
+
+private extension Gemma2_9B {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
+@Test
+func canLoadAndQueryGemma2_9B() async throws {
+    let llm = try await Gemma2_9B()
+    let result = try await llm.request(.init(messages: [
+        ["role": "system", "content": "You are a helpful assistant."],
+        ["role": "user", "content": "What is the meaning of life?"],
+    ]))
+    Swift.print(result)
+    #expect(!result.isEmpty)
+}

--- a/Tests/SHLLMTests/Models/GemmaTests.swift
+++ b/Tests/SHLLMTests/Models/GemmaTests.swift
@@ -1,0 +1,19 @@
+@testable import SHLLM
+import Testing
+
+private extension Gemma {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
+@Test
+func canLoadAndQueryGemma() async throws {
+    let llm = try await Gemma()
+    let result = try await llm.request(.init(messages: [
+        ["role": "system", "content": "You are a helpful assistant."],
+        ["role": "user", "content": "What is the meaning of life?"],
+    ]))
+    Swift.print(result)
+    #expect(!result.isEmpty)
+}

--- a/Tests/SHLLMTests/Models/Llama3-8BTests.swift
+++ b/Tests/SHLLMTests/Models/Llama3-8BTests.swift
@@ -1,0 +1,19 @@
+@testable import SHLLM
+import Testing
+
+private extension Llama3_8B {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
+@Test
+func canLoadAndQueryLlama3_8B() async throws {
+    let llm = try await Llama3_8B()
+    let result = try await llm.request(.init(messages: [
+        ["role": "system", "content": "You are a helpful assistant."],
+        ["role": "user", "content": "What is the meaning of life?"],
+    ]))
+    Swift.print(result)
+    #expect(!result.isEmpty)
+}

--- a/Tests/SHLLMTests/Models/Llama3_1-8BTests.swift
+++ b/Tests/SHLLMTests/Models/Llama3_1-8BTests.swift
@@ -1,0 +1,19 @@
+@testable import SHLLM
+import Testing
+
+private extension Llama3_1__8B {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
+@Test
+func canLoadAndQueryLlama3_1__8B() async throws {
+    let llm = try await Llama3_1__8B()
+    let result = try await llm.request(.init(messages: [
+        ["role": "system", "content": "You are a helpful assistant."],
+        ["role": "user", "content": "What is the meaning of life?"],
+    ]))
+    Swift.print(result)
+    #expect(!result.isEmpty)
+}

--- a/Tests/SHLLMTests/Models/Llama3_2-1BTests.swift
+++ b/Tests/SHLLMTests/Models/Llama3_2-1BTests.swift
@@ -1,0 +1,19 @@
+@testable import SHLLM
+import Testing
+
+private extension Llama3_2__1B {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
+@Test
+func canLoadAndQueryLlama3_2__1B() async throws {
+    let llm = try await Llama3_2__1B()
+    let result = try await llm.request(.init(messages: [
+        ["role": "system", "content": "You are a helpful assistant."],
+        ["role": "user", "content": "What is the meaning of life?"],
+    ]))
+    Swift.print(result)
+    #expect(!result.isEmpty)
+}

--- a/Tests/SHLLMTests/Models/Llama3_2-3BTests.swift
+++ b/Tests/SHLLMTests/Models/Llama3_2-3BTests.swift
@@ -1,0 +1,19 @@
+@testable import SHLLM
+import Testing
+
+private extension Llama3_2__3B {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
+@Test
+func canLoadAndQueryLlama3_2__3B() async throws {
+    let llm = try await Llama3_2__3B()
+    let result = try await llm.request(.init(messages: [
+        ["role": "system", "content": "You are a helpful assistant."],
+        ["role": "user", "content": "What is the meaning of life?"],
+    ]))
+    Swift.print(result)
+    #expect(!result.isEmpty)
+}

--- a/Tests/SHLLMTests/Models/Mistral7BTests.swift
+++ b/Tests/SHLLMTests/Models/Mistral7BTests.swift
@@ -1,0 +1,19 @@
+@testable import SHLLM
+import Testing
+
+private extension Mistral7B {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
+@Test
+func canLoadAndQueryMistral7B() async throws {
+    let llm = try await Mistral7B()
+    let result = try await llm.request(.init(messages: [
+        ["role": "system", "content": "You are a helpful assistant."],
+        ["role": "user", "content": "What is the meaning of life?"],
+    ]))
+    Swift.print(result)
+    #expect(!result.isEmpty)
+}

--- a/Tests/SHLLMTests/Models/MistralNemoTests.swift
+++ b/Tests/SHLLMTests/Models/MistralNemoTests.swift
@@ -1,0 +1,19 @@
+@testable import SHLLM
+import Testing
+
+private extension MistralNemo {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
+@Test
+func canLoadAndQueryMistralNemo() async throws {
+    let llm = try await MistralNemo()
+    let result = try await llm.request(.init(messages: [
+        ["role": "system", "content": "You are a helpful assistant."],
+        ["role": "user", "content": "What is the meaning of life?"],
+    ]))
+    Swift.print(result)
+    #expect(!result.isEmpty)
+}

--- a/Tests/SHLLMTests/Models/OpenELMTests.swift
+++ b/Tests/SHLLMTests/Models/OpenELMTests.swift
@@ -1,0 +1,19 @@
+@testable import SHLLM
+import Testing
+
+private extension OpenELM {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
+@Test
+func canLoadAndQueryOpenELM() async throws {
+    let llm = try await OpenELM()
+    let result = try await llm.request(.init(messages: [
+        ["role": "system", "content": "You are a helpful assistant."],
+        ["role": "user", "content": "What is the meaning of life?"],
+    ]))
+    Swift.print(result)
+    #expect(!result.isEmpty)
+}

--- a/Tests/SHLLMTests/Models/Phi2Tests.swift
+++ b/Tests/SHLLMTests/Models/Phi2Tests.swift
@@ -1,0 +1,19 @@
+@testable import SHLLM
+import Testing
+
+private extension Phi2 {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
+@Test
+func canLoadAndQueryPhi2() async throws {
+    let llm = try await Phi2()
+    let result = try await llm.request(.init(messages: [
+        ["role": "system", "content": "You are a helpful assistant."],
+        ["role": "user", "content": "What is the meaning of life?"],
+    ]))
+    Swift.print(result)
+    #expect(!result.isEmpty)
+}

--- a/Tests/SHLLMTests/Models/Phi3Tests.swift
+++ b/Tests/SHLLMTests/Models/Phi3Tests.swift
@@ -1,16 +1,16 @@
 @testable import SHLLM
 import Testing
 
-extension Phi3 {
+private extension Phi3 {
     init() async throws {
         try await self.init(directory: Self.bundleDirectory)
     }
 }
 
 @Test
-func canLoadAndQueryModel() async throws {
-    let phi3 = try await Phi3()
-    let result = try await phi3.request(.init(messages: [
+func canLoadAndQueryPhi3() async throws {
+    let llm = try await Phi3()
+    let result = try await llm.request(.init(messages: [
         ["role": "system", "content": "You are a helpful assistant."],
         ["role": "user", "content": "What is the meaning of life?"],
     ]))

--- a/Tests/SHLLMTests/Models/PhiMoETests.swift
+++ b/Tests/SHLLMTests/Models/PhiMoETests.swift
@@ -1,0 +1,19 @@
+@testable import SHLLM
+import Testing
+
+private extension PhiMoE {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
+@Test
+func canLoadAndQueryPhiMoE() async throws {
+    let llm = try await PhiMoE()
+    let result = try await llm.request(.init(messages: [
+        ["role": "system", "content": "You are a helpful assistant."],
+        ["role": "user", "content": "What is the meaning of life?"],
+    ]))
+    Swift.print(result)
+    #expect(!result.isEmpty)
+}

--- a/Tests/SHLLMTests/Models/Qwen1_5Tests.swift
+++ b/Tests/SHLLMTests/Models/Qwen1_5Tests.swift
@@ -1,0 +1,19 @@
+@testable import SHLLM
+import Testing
+
+private extension Qwen1_5 {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
+@Test
+func canLoadAndQueryQwen1_5() async throws {
+    let llm = try await Qwen1_5()
+    let result = try await llm.request(.init(messages: [
+        ["role": "system", "content": "You are a helpful assistant."],
+        ["role": "user", "content": "What is the meaning of life?"],
+    ]))
+    Swift.print(result)
+    #expect(!result.isEmpty)
+}

--- a/Tests/SHLLMTests/Models/Qwen2_5-1_5BTests.swift
+++ b/Tests/SHLLMTests/Models/Qwen2_5-1_5BTests.swift
@@ -1,0 +1,19 @@
+@testable import SHLLM
+import Testing
+
+private extension Qwen2_5__1_5B {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
+@Test
+func canLoadAndQueryQwen2_5__1_5B() async throws {
+    let llm = try await Qwen2_5__1_5B()
+    let result = try await llm.request(.init(messages: [
+        ["role": "system", "content": "You are a helpful assistant."],
+        ["role": "user", "content": "What is the meaning of life?"],
+    ]))
+    Swift.print(result)
+    #expect(!result.isEmpty)
+}

--- a/Tests/SHLLMTests/Models/Qwen2_5-7BTests.swift
+++ b/Tests/SHLLMTests/Models/Qwen2_5-7BTests.swift
@@ -1,0 +1,19 @@
+@testable import SHLLM
+import Testing
+
+private extension Qwen2_5__7B {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
+@Test
+func canLoadAndQueryQwen2_5__7B() async throws {
+    let llm = try await Qwen2_5__7B()
+    let result = try await llm.request(.init(messages: [
+        ["role": "system", "content": "You are a helpful assistant."],
+        ["role": "user", "content": "What is the meaning of life?"],
+    ]))
+    Swift.print(result)
+    #expect(!result.isEmpty)
+}

--- a/Tests/SHLLMTests/Models/SmolLMTests.swift
+++ b/Tests/SHLLMTests/Models/SmolLMTests.swift
@@ -1,0 +1,19 @@
+@testable import SHLLM
+import Testing
+
+private extension SmolLM {
+    init() async throws {
+        try await self.init(directory: Self.bundleDirectory)
+    }
+}
+
+@Test
+func canLoadAndQuerySmolLM() async throws {
+    let llm = try await SmolLM()
+    let result = try await llm.request(.init(messages: [
+        ["role": "system", "content": "You are a helpful assistant."],
+        ["role": "user", "content": "What is the meaning of life?"],
+    ]))
+    Swift.print(result)
+    #expect(!result.isEmpty)
+}


### PR DESCRIPTION
This pull request exposes a simple actor for each supported model. The actual implementation of the models is `LLM`, which is just a convenience wrapper around MLX's stuff.

Each model conforms to a new protocol called `ModelProtocol`. This allows us to add extra functions for each model in just a single place: ModelProtocol.swift. The first example of this is `request(_:maxTokenCount:)`.

Because of the reentrancy problem with Swift Actors, `ModelProtocol.llm` is wrapped inside of `ActorLock`, which is taken from [Apple's swift-build/ASyncLock.swift](https://github.com/swiftlang/swift-build/blob/main/Sources/SWBUtil/AsyncLock.swift).

According to MLX's documentation, the AI models themselves are not thread-safe, which means calls to them need to be serialized. However, because Swift Actors are reentrant, calling `try await llm.request(_:maxTokenCount:)` could immediately suspend and allow another reference to the same actor be called. This may not be a problem with library today, but I think it may be in the future, especially when we add support for `KVCache`. I think it's better to ensure that every call to `ModelProtocol.someFunc` is transactional, which is what we are doing by wrapping the implementation of every method on `ModelProtocol` inside of a `AsyncLock`.