### PR TITLE
Add processing LLM argument and update mlx-swift-examples

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/johnmai-dev/Jinja",
       "state" : {
-        "revision" : "31c4dd39bcdc07eaa42a384bdc88ea599022b800",
-        "version" : "1.1.2"
+        "revision" : "fc1233dea1142897d474bda2f1f9a6c3fe7acab6",
+        "version" : "1.2.1"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/shareup/mlx-swift-examples",
       "state" : {
-        "revision" : "c4ecbb561d1ca2efcb5804e527387b08c91df416",
-        "version" : "0.0.9"
+        "revision" : "a5ab7b8453179e1e9943f7c8ae803bd13533b8a3",
+        "version" : "0.0.10"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
-        "revision" : "c2f302a74cca59cbde683b1425ab43c05685515a",
-        "version" : "0.1.21"
+        "revision" : "e5bf0627bd134cf8ddc407cda403ae84207af959",
+        "version" : "0.1.22"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,11 +13,11 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/apple/swift-async-algorithms",
-            from: "1.0.0"
+            from: "1.0.4"
         ),
         .package(
             url: "https://github.com/shareup/mlx-swift-examples",
-            from: "0.0.9"
+            from: "0.0.10"
         ),
         .package(
             url: "https://github.com/huggingface/swift-transformers",

--- a/Sources/SHLLM/LLM.swift
+++ b/Sources/SHLLM/LLM.swift
@@ -29,6 +29,7 @@ public struct LLM<Model: LanguageModel>: AsyncSequence {
     public init(
         directory: URL,
         input: UserInput,
+        processing: UserInput.Processing? = nil,
         tools: [any ToolProtocol] = [],
         maxInputTokenCount: Int? = nil,
         maxOutputTokenCount: Int? = nil,
@@ -37,9 +38,9 @@ public struct LLM<Model: LanguageModel>: AsyncSequence {
         self.directory = directory
         let input = {
             var input = input
-            input.processing.resize = Model.self is any VLMModel.Type
-                ? CGSize(width: 896, height: 896)
-                : nil
+            if let processing {
+                input.processing = processing
+            }
             input.tools = tools.isEmpty
                 ? nil
                 : tools.map(\.schema)
@@ -250,6 +251,7 @@ public extension LLM where Model: VLMModel {
         prompt: String,
         userMessage: String,
         image: URL,
+        processing: UserInput.Processing? = nil,
         maxInputTokenCount: Int? = nil,
         maxOutputTokenCount: Int? = nil,
         customConfiguration: CustomConfiguration? = nil
@@ -261,6 +263,7 @@ public extension LLM where Model: VLMModel {
         self.init(
             directory: directory,
             input: input,
+            processing: processing,
             maxInputTokenCount: maxInputTokenCount,
             maxOutputTokenCount: maxOutputTokenCount,
             customConfiguration: customConfiguration
@@ -272,6 +275,7 @@ public extension LLM where Model: VLMModel {
         prompt: String,
         userMessage: String,
         image: Data,
+        processing: UserInput.Processing? = nil,
         maxInputTokenCount: Int? = nil,
         maxOutputTokenCount: Int? = nil,
         customConfiguration: CustomConfiguration? = nil
@@ -286,6 +290,7 @@ public extension LLM where Model: VLMModel {
         self.init(
             directory: directory,
             input: input,
+            processing: processing,
             maxInputTokenCount: maxInputTokenCount,
             maxOutputTokenCount: maxOutputTokenCount,
             customConfiguration: customConfiguration
@@ -430,6 +435,7 @@ extension LLM where Model == Gemma3 {
     public static func gemma3_4B(
         directory: URL,
         input: UserInput,
+        processing: UserInput.Processing = .init(resize: CGSize(width: 896, height: 896)),
         maxInputTokenCount: Int? = nil,
         maxOutputTokenCount: Int? = nil
     ) throws -> LLM<Gemma3> {
@@ -437,6 +443,7 @@ extension LLM where Model == Gemma3 {
         return .init(
             directory: directory,
             input: input,
+            processing: processing,
             maxInputTokenCount: maxInputTokenCount,
             maxOutputTokenCount: maxOutputTokenCount,
             customConfiguration: { config in
@@ -457,6 +464,7 @@ extension LLM where Model == Gemma3 {
     public static func gemma3_12B(
         directory: URL,
         input: UserInput,
+        processing: UserInput.Processing = .init(resize: CGSize(width: 896, height: 896)),
         maxInputTokenCount: Int? = nil,
         maxOutputTokenCount: Int? = nil
     ) throws -> LLM<Gemma3> {
@@ -464,6 +472,7 @@ extension LLM where Model == Gemma3 {
         return .init(
             directory: directory,
             input: input,
+            processing: processing,
             maxInputTokenCount: maxInputTokenCount,
             maxOutputTokenCount: maxOutputTokenCount,
             customConfiguration: { config in
@@ -484,6 +493,7 @@ extension LLM where Model == Gemma3 {
     public static func gemma3_27B(
         directory: URL,
         input: UserInput,
+        processing: UserInput.Processing = .init(resize: CGSize(width: 896, height: 896)),
         maxInputTokenCount: Int? = nil,
         maxOutputTokenCount: Int? = nil
     ) throws -> LLM<Gemma3> {
@@ -491,6 +501,7 @@ extension LLM where Model == Gemma3 {
         return .init(
             directory: directory,
             input: input,
+            processing: processing,
             maxInputTokenCount: maxInputTokenCount,
             maxOutputTokenCount: maxOutputTokenCount,
             customConfiguration: { config in

--- a/Tests/SHLLMTests/Helpers.swift
+++ b/Tests/SHLLMTests/Helpers.swift
@@ -4,6 +4,7 @@ import SHLLM
 func loadModel<M>(
     directory: @autoclosure () throws -> URL,
     input: @autoclosure () -> UserInput,
+    processing: @autoclosure (() -> UserInput.Processing?) = nil,
     tools: [any ToolProtocol] = [],
     maxOutputTokenCount: @autoclosure () -> Int? = nil,
     customConfiguration: LLM.CustomConfiguration? = nil
@@ -16,6 +17,7 @@ func loadModel<M>(
             return LLM(
                 directory: try directory(),
                 input: input(),
+                processing: processing(),
                 tools: tools,
                 maxOutputTokenCount: maxOutputTokenCount(),
                 customConfiguration: customConfiguration

--- a/Tests/SHLLMTests/Tool+SHLLMTests.swift
+++ b/Tests/SHLLMTests/Tool+SHLLMTests.swift
@@ -6,7 +6,7 @@ import Testing
 @Suite(.serialized)
 struct ToolSHLLMTests {
     @Test
-    func testToolProtocolTypeProperty() throws {
+    func toolProtocolTypeProperty() throws {
         let tool = Tool<EmptyInput, EmptyOutput>(
             name: "test_tool",
             description: "A test tool",
@@ -17,7 +17,7 @@ struct ToolSHLLMTests {
     }
 
     @Test
-    func testToolProtocolNameProperty() throws {
+    func toolProtocolNameProperty() throws {
         let tool = Tool<EmptyInput, EmptyOutput>(
             name: "get_weather",
             description: "Gets weather data",
@@ -28,7 +28,7 @@ struct ToolSHLLMTests {
     }
 
     @Test
-    func testToolProtocolDescriptionProperty() throws {
+    func toolProtocolDescriptionProperty() throws {
         let tool = Tool<EmptyInput, EmptyOutput>(
             name: "test_tool",
             description: "This is a test tool for validation",
@@ -39,7 +39,7 @@ struct ToolSHLLMTests {
     }
 
     @Test
-    func testToolProtocolParametersProperty() throws {
+    func toolProtocolParametersProperty() throws {
         let tool = Tool<TestInput, EmptyOutput>(
             name: "test_tool",
             description: "A test tool",
@@ -67,7 +67,7 @@ struct ToolSHLLMTests {
     }
 
     @Test
-    func testParametersWithComplexTypes() throws {
+    func parametersWithComplexTypes() throws {
         let tool = Tool<ComplexInput, EmptyOutput>(
             name: "complex_tool",
             description: "A tool with complex parameters",
@@ -106,7 +106,7 @@ struct ToolSHLLMTests {
     }
 
     @Test
-    func testParametersWithExtraProperties() throws {
+    func parametersWithExtraProperties() throws {
         let tool = Tool<TestInput, EmptyOutput>(
             name: "test_tool",
             description: "A test tool",
@@ -142,7 +142,7 @@ struct ToolSHLLMTests {
     }
 
     @Test
-    func testToolParameterTypeEquality() {
+    func toolParameterTypeEquality() {
         #expect(ToolParameterType.string == ToolParameterType.string)
         #expect(ToolParameterType.bool == ToolParameterType.bool)
         #expect(ToolParameterType.int == ToolParameterType.int)
@@ -234,7 +234,7 @@ struct ToolSHLLMTests {
     }
 
     @Test
-    func testToolParameterEquality() {
+    func toolParameterEquality() {
         let param1 = ToolParameter.required("test", type: .string, description: "Test param")
         let param2 = ToolParameter.required("test", type: .string, description: "Test param")
         #expect(param1 == param2)
@@ -409,7 +409,7 @@ struct ToolSHLLMTests {
     }
 
     @Test
-    func testInvalidSchemaHandling() {
+    func invalidSchemaHandling() {
         let invalidTool = TestInvalidTool()
 
         #expect(invalidTool.type == nil)
@@ -419,7 +419,7 @@ struct ToolSHLLMTests {
     }
 
     @Test
-    func testSchemaWithMissingFunction() {
+    func schemaWithMissingFunction() {
         let toolWithMissingFunction = TestToolWithMissingFunction()
 
         #expect(toolWithMissingFunction.type == "function")
@@ -429,7 +429,7 @@ struct ToolSHLLMTests {
     }
 
     @Test
-    func testSchemaWithInvalidParameters() {
+    func schemaWithInvalidParameters() {
         let toolWithInvalidParams = TestToolWithInvalidParameters()
 
         #expect(toolWithInvalidParams.type == "function")
@@ -439,7 +439,7 @@ struct ToolSHLLMTests {
     }
 
     @Test
-    func testNestedObjectParsing() throws {
+    func nestedObjectParsing() throws {
         let tool = Tool<NestedInput, EmptyOutput>(
             name: "nested_tool",
             description: "A tool with nested objects",
@@ -494,7 +494,7 @@ struct ToolSHLLMTests {
     }
 
     @Test
-    func testArrayOfComplexTypes() throws {
+    func arrayOfComplexTypes() throws {
         let tool = Tool<ArrayInput, EmptyOutput>(
             name: "array_tool",
             description: "A tool with array of objects",

--- a/Tests/SHLLMTests/ToolTests.swift
+++ b/Tests/SHLLMTests/ToolTests.swift
@@ -93,7 +93,7 @@ struct ToolTests {
     }
 
     @Test
-    func testJSONIntegration() throws {
+    func jsonIntegration() throws {
         struct ComplexInput: Codable {
             let query: String
             let filters: [String]

--- a/Tests/SHLLMTests/TruncatingUserInputProcessorTests.swift
+++ b/Tests/SHLLMTests/TruncatingUserInputProcessorTests.swift
@@ -8,7 +8,7 @@ import Tokenizers
 @Suite(.serialized)
 struct TruncatingUserInputProcessorTests {
     @Test
-    func testTextPromptTruncation() async throws {
+    func textPromptTruncation() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -28,7 +28,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testChatMessagesPreserveSystem() async throws {
+    func chatMessagesPreserveSystem() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -53,7 +53,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testRawMessagesPreserveSystem() async throws {
+    func rawMessagesPreserveSystem() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -78,7 +78,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testSystemMessagesOnlyExceedsLimit() async throws {
+    func systemMessagesOnlyExceedsLimit() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -99,7 +99,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testRawSystemMessagesOnlyExceedsLimit() async throws {
+    func rawSystemMessagesOnlyExceedsLimit() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -120,7 +120,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testNoMessageTruncationWhenUnderLimit() async throws {
+    func noMessageTruncationWhenUnderLimit() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -143,7 +143,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testNoRawMessageTruncationWhenUnderLimit() async throws {
+    func noRawMessageTruncationWhenUnderLimit() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -166,7 +166,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testNoLimitPassesThrough() async throws {
+    func noLimitPassesThrough() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -184,7 +184,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testRecentMessagesKept() async throws {
+    func recentMessagesKept() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -209,7 +209,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testRecentRawMessagesKept() async throws {
+    func recentRawMessagesKept() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -234,7 +234,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testAlternatingAlgorithm() async throws {
+    func alternatingAlgorithm() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -263,7 +263,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testMessageFlattening() async throws {
+    func messageFlattening() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -289,7 +289,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testRawMessageFlattening() async throws {
+    func rawMessageFlattening() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -315,7 +315,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testEmptyMessages() async throws {
+    func emptyMessages() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -331,7 +331,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testSingleMessage() async throws {
+    func singleMessage() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -352,7 +352,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testExactTokenLimit() async throws {
+    func exactTokenLimit() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -374,7 +374,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testSingleMessageExceedsTokenLimit() async throws {
+    func singleMessageExceedsTokenLimit() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -395,7 +395,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testSingleRawMessageExceedsTokenLimit() async throws {
+    func singleRawMessageExceedsTokenLimit() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -416,7 +416,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testOnlySystemMessages() async throws {
+    func onlySystemMessages() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -437,7 +437,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testMultipleSystemMessages() async throws {
+    func multipleSystemMessages() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(
@@ -462,7 +462,7 @@ struct TruncatingUserInputProcessorTests {
     }
 
     @Test
-    func testVeryLongFirstMessage() async throws {
+    func veryLongFirstMessage() async throws {
         let tokenizer = NaiveTokenizer()
         let baseProcessor = NaiveInputProcessor()
         let processor = TruncatingUserInputProcessor(


### PR DESCRIPTION
The `processing: UserInput.Processing?` argument in `LLM.init()` was added because it was hoped that, by decreasing the resizing size of images passed to vision models, inference could happen faster and with fewer resources. Unfortunately, at least in the case of Gemma 3 models, the resizing value in `UserInput.Processing` is ignored in favor of the hard-coded values from the model's configuration. Since other processing options may be added in the future, though, the decision was made to keep the `UserInput.Processing` argument since it did not change the public interface or behavior of the current implementation at all.