### PR TITLE
Get and set cache and memory limits

### DIFF
--- a/Sources/SHLLM/LLM.swift
+++ b/Sources/SHLLM/LLM.swift
@@ -435,7 +435,6 @@ extension LLM where Model == Gemma3 {
     public static func gemma3_4B(
         directory: URL,
         input: UserInput,
-        processing: UserInput.Processing = .init(resize: CGSize(width: 896, height: 896)),
         maxInputTokenCount: Int? = nil,
         maxOutputTokenCount: Int? = nil
     ) throws -> LLM<Gemma3> {
@@ -443,7 +442,6 @@ extension LLM where Model == Gemma3 {
         return .init(
             directory: directory,
             input: input,
-            processing: processing,
             maxInputTokenCount: maxInputTokenCount,
             maxOutputTokenCount: maxOutputTokenCount,
             customConfiguration: { config in
@@ -464,7 +462,6 @@ extension LLM where Model == Gemma3 {
     public static func gemma3_12B(
         directory: URL,
         input: UserInput,
-        processing: UserInput.Processing = .init(resize: CGSize(width: 896, height: 896)),
         maxInputTokenCount: Int? = nil,
         maxOutputTokenCount: Int? = nil
     ) throws -> LLM<Gemma3> {
@@ -472,7 +469,6 @@ extension LLM where Model == Gemma3 {
         return .init(
             directory: directory,
             input: input,
-            processing: processing,
             maxInputTokenCount: maxInputTokenCount,
             maxOutputTokenCount: maxOutputTokenCount,
             customConfiguration: { config in
@@ -493,7 +489,6 @@ extension LLM where Model == Gemma3 {
     public static func gemma3_27B(
         directory: URL,
         input: UserInput,
-        processing: UserInput.Processing = .init(resize: CGSize(width: 896, height: 896)),
         maxInputTokenCount: Int? = nil,
         maxOutputTokenCount: Int? = nil
     ) throws -> LLM<Gemma3> {
@@ -501,7 +496,6 @@ extension LLM where Model == Gemma3 {
         return .init(
             directory: directory,
             input: input,
-            processing: processing,
             maxInputTokenCount: maxInputTokenCount,
             maxOutputTokenCount: maxOutputTokenCount,
             customConfiguration: { config in

--- a/Sources/SHLLM/SHLLM.swift
+++ b/Sources/SHLLM/SHLLM.swift
@@ -8,6 +8,31 @@ public enum SHLLM {
         MLX.GPU.clearCache()
     }
 
+    public static var cacheLimit: Int {
+        get {
+            MLX.GPU.cacheLimit
+        }
+        set {
+            MLX.GPU.set(cacheLimit: newValue)
+        }
+    }
+
+    public static var memoryLimit: Int {
+        get {
+            MLX.GPU.memoryLimit
+        }
+        set {
+            MLX.GPU.set(memoryLimit: newValue)
+        }
+    }
+
+    public static var recommendedMaxWorkingSetSize: Int {
+        guard let device = MTLCreateSystemDefaultDevice(),
+              device.recommendedMaxWorkingSetSize < Int.max
+        else { return 0 }
+        return Int(device.recommendedMaxWorkingSetSize)
+    }
+
     public static var isSupportedDevice: Bool {
         guard let _ = MTLCreateSystemDefaultDevice() else {
             return false

--- a/Tests/SHLLMTests/SHLLMTests.swift
+++ b/Tests/SHLLMTests/SHLLMTests.swift
@@ -5,3 +5,25 @@ import Testing
 func canBuildLibrary() async throws {
     #expect(Bool(true))
 }
+
+@Test
+func cacheLimit() async throws {
+    let limit = 1024
+    #expect(SHLLM.cacheLimit != limit)
+    SHLLM.cacheLimit = limit
+    #expect(SHLLM.cacheLimit == limit)
+}
+
+@Test
+func memoryLimit() async throws {
+    let limit = 1024
+    #expect(SHLLM.memoryLimit != limit)
+    SHLLM.memoryLimit = limit
+    #expect(SHLLM.memoryLimit == limit)
+}
+
+@Test
+func recommendedMaxWorkingSetSize() async throws {
+    let recommended = SHLLM.recommendedMaxWorkingSetSize
+    #expect(recommended > 0)
+}


### PR DESCRIPTION
- Add `SHLLM.cacheLimit`, `SHLLM.memoryLimit`, and `SHLLM.recommendedMaxWorkingSetSize`
- Remove `processing: UserInput.Processing` argument from Gemma 3 initializers 