### PR TITLE
withDefaultDevice()

### DIFF
--- a/Sources/SHLLM/SHLLM.swift
+++ b/Sources/SHLLM/SHLLM.swift
@@ -26,6 +26,20 @@ public enum SHLLM {
         }
     }
 
+    public static var recommendedMaxWorkingSetSize: Int {
+        guard let device = MTLCreateSystemDefaultDevice(),
+              device.recommendedMaxWorkingSetSize < Int.max
+        else { return 0 }
+        return Int(device.recommendedMaxWorkingSetSize)
+    }
+
+    public static var isSupportedDevice: Bool {
+        guard let _ = MTLCreateSystemDefaultDevice() else {
+            return false
+        }
+        return true
+    }
+
     public static func withDefaultDevice<R>(
         _ device: MLX.DeviceType,
         _ body: () throws -> R
@@ -48,20 +62,6 @@ public enum SHLLM {
         case .gpu:
             try await MLX.Device.withDefaultDevice(.gpu, body)
         }
-    }
-
-    public static var recommendedMaxWorkingSetSize: Int {
-        guard let device = MTLCreateSystemDefaultDevice(),
-              device.recommendedMaxWorkingSetSize < Int.max
-        else { return 0 }
-        return Int(device.recommendedMaxWorkingSetSize)
-    }
-
-    public static var isSupportedDevice: Bool {
-        guard let _ = MTLCreateSystemDefaultDevice() else {
-            return false
-        }
-        return true
     }
 
     static var assertSupportedDevice: Void {

--- a/Sources/SHLLM/SHLLM.swift
+++ b/Sources/SHLLM/SHLLM.swift
@@ -26,6 +26,30 @@ public enum SHLLM {
         }
     }
 
+    public static func withDefaultDevice<R>(
+        _ device: MLX.DeviceType,
+        _ body: () throws -> R
+    ) rethrows -> R {
+        switch device {
+        case .cpu:
+            try MLX.Device.withDefaultDevice(.cpu, body)
+        case .gpu:
+            try MLX.Device.withDefaultDevice(.gpu, body)
+        }
+    }
+
+    public static func withDefaultDevice<R>(
+        _ device: MLX.DeviceType,
+        _ body: () async throws -> R
+    ) async rethrows -> R {
+        switch device {
+        case .cpu:
+            try await MLX.Device.withDefaultDevice(.cpu, body)
+        case .gpu:
+            try await MLX.Device.withDefaultDevice(.gpu, body)
+        }
+    }
+
     public static var recommendedMaxWorkingSetSize: Int {
         guard let device = MTLCreateSystemDefaultDevice(),
               device.recommendedMaxWorkingSetSize < Int.max
@@ -59,6 +83,8 @@ public enum SHLLM {
 @_exported import protocol MLXLMCommon.ToolProtocol
 
 extension Chat.Message: @retroactive @unchecked Sendable {}
+
+@_exported import enum MLX.DeviceType
 
 @_exported import protocol MLXLMCommon.LanguageModel
 


### PR DESCRIPTION
Expose `SHLLM.withDefaultDevice(_:_:)` to allow clients to run inference on the CPU or GPU.